### PR TITLE
Check for https in vcf file names

### DIFF
--- a/variantpattern/variant_pattern_finder.pl
+++ b/variantpattern/variant_pattern_finder.pl
@@ -244,7 +244,7 @@ sub parse_sample_file {
 	
 	my @sample_panel_lines;
 	my %total_sample_cnt_hash;
-	if ($sample_panel =~ /http:\/\/([\w.]+)(\/\S+)/) {
+	if ($sample_panel =~ /https?:\/\/([\w.]+)(\/\S+)/) {
 		my $ftp_host = $1;
 		my $path = $2;
 		

--- a/vcftoped/vcftoped.pl
+++ b/vcftoped/vcftoped.pl
@@ -82,7 +82,7 @@ my $is_compressed = $vcf =~ /\.b?gz(ip)?$/;
 if ($is_compressed) {
   $tabix ||= "$tools_dir/linuxbrew/bin/tabix";
 }
-die("remote vcf file must be compressed by bgzip") if (!$is_compressed && $vcf =~ /http:\/\//);
+die("remote vcf file must be compressed by bgzip") if (!$is_compressed && $vcf =~ /https?:\/\//);
 
 my ($region_chromosome, $region_start, $region_end);
 if ($region =~ /^(\w+):(\d+)-(\d+)$/) {
@@ -249,7 +249,7 @@ sub get_individuals {
 
     my @sample_panel_lines;
 
-    if ($sample_panel =~ /http:\/\/([\w.]+)(\/\S+)/) {
+    if ($sample_panel =~ /https?:\/\/([\w.]+)(\/\S+)/) {
         my $ftp_host = $1;
         my $path = $2;
 


### PR DESCRIPTION
Not checking for https and only for https in VCF file names results in using the wrong method to open these files. This results in an error as mentioned by many users in RT tickets such as: https://helpdesk.ebi.ac.uk/Ticket/Display.html?id=621306. In order to check for both http and https, the regex had to be slightly tweaked. This should make the code use the correct method to access these files (`Net::FTP` - https://metacpan.org/pod/Net::FTP::File).

JIRA: [ENSWEB-6755](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6755)

There is also a related PR in which the check for FTP protocol was replaced by HTTP: https://github.com/Ensembl/1000G-tools/pull/4

I couldn't figure out how to setup the sandbox for this. However, I have tried this in a regex playground online: https://regex101.com/r/iPqtlR/1